### PR TITLE
chore: prefer detecting boiler from --package in addCve()

### DIFF
--- a/cvelib/cve.py
+++ b/cvelib/cve.py
@@ -1123,13 +1123,11 @@ def addCve(
     exists: bool = os.path.exists(cve_fn)
 
     # For a new CVE (where the path doesn't already exist), if we can determine
-    # a pkg from the candidate, then add it to the front of the list, removing
-    # it from the pkgs if it is already there
+    # a pkg from the candidate, then add it to the list if we haven't specified
+    # any packages with --package already
     p: Optional[str] = pkgFromCandidate(cand, where)
-    if not exists and p:
-        if p in pkgs:
-            pkgs.remove(p)
-        pkgs.insert(0, p)
+    if not exists and p and len(pkgs) == 0:
+        pkgs.append(p)
     if not pkgs:
         raise CveException("could not find usable packages for '%s'" % orig_cve)
 


### PR DESCRIPTION
Previously, addCve() would unconditionally prepend the detected pkg from the URL which would cause it to always be used as the boiler when --package-boiler was not specified. Clear this up so that:

* cve-add -c https://github.com/foo/bar/issues/1 uses 'bar' boilerplate if it exists
* cve-add -c https://github.com/foo/bar/issues/1 -p foo_baz uses 'baz' boilerplate if it exists
* cve-add -c https://github.com/foo/bar/issues/1 -p foo_baz -p foo_norf uses 'baz' boilerplate if it exists
* cve-add -c https://github.com/foo/bar/issues/1 -p foo_baz -p foo_norf --package-boiler=corge uses 'corge' boilerplate if it exists