### PR TITLE
chore: remove unsupported Author from license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,4 @@
-Copyright (c) 2023 InfluxData
-Author: Jamie Strandboge <jamie@influxdata.com>
+Copyright (c) 2021-2023 InfluxData
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/bin/cve-add
+++ b/bin/cve-add
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/bin/cve-check-syntax
+++ b/bin/cve-check-syntax
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/bin/cve-edit
+++ b/bin/cve-edit
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/bin/cve-nfu
+++ b/bin/cve-nfu
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/bin/cve-report
+++ b/bin/cve-report
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/bin/cve-report-updated-bugs
+++ b/bin/cve-report-updated-bugs
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/bin/gar-report
+++ b/bin/gar-report
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/bin/gh-report
+++ b/bin/gh-report
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/bin/quay-report
+++ b/bin/quay-report
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/common.py
+++ b/cvelib/common.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/cve-compat.vim
+++ b/cvelib/cve-compat.vim
@@ -1,7 +1,6 @@
 " Vim syntax file for 'compat' CVE entries
 "
-" Copyright (c) 2023 InfluxData
-" Author: Jamie Strandboge <jamie@influxdata.com>
+" Copyright (c) 2021-2023 InfluxData
 "
 " Permission is hereby granted, free of charge, to any
 " person obtaining a copy of this software and associated

--- a/cvelib/cve.py
+++ b/cvelib/cve.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/cve.vim
+++ b/cvelib/cve.vim
@@ -1,7 +1,6 @@
 " Vim syntax file for CVE entries
 "
-" Copyright (c) 2023 InfluxData
-" Author: Jamie Strandboge <jamie@influxdata.com>
+" Copyright (c) 2021-2023 InfluxData
 "
 " Permission is hereby granted, free of charge, to any
 " person obtaining a copy of this software and associated

--- a/cvelib/gar.py
+++ b/cvelib/gar.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/github.py
+++ b/cvelib/github.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/net.py
+++ b/cvelib/net.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/pkg.py
+++ b/cvelib/pkg.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/quay.py
+++ b/cvelib/quay.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/report.py
+++ b/cvelib/report.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/run-black
+++ b/cvelib/run-black
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/run-flake8
+++ b/cvelib/run-flake8
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/run-py-helper
+++ b/cvelib/run-py-helper
@@ -1,7 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/run-pylint
+++ b/cvelib/run-pylint
@@ -1,7 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/run-tests
+++ b/cvelib/run-tests
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/test_common.py
+++ b/cvelib/test_common.py
@@ -1,7 +1,6 @@
 """test_common.py: tests for common.py module"""
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/test_cve.py
+++ b/cvelib/test_cve.py
@@ -1,7 +1,6 @@
 """test_cve.py: tests for cve.py module"""
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/test_github.py
+++ b/cvelib/test_github.py
@@ -1,7 +1,6 @@
 """test_github.py: tests for github.py module"""
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/test_net.py
+++ b/cvelib/test_net.py
@@ -1,7 +1,6 @@
 """test_net.py: tests for net.py module"""
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/test_pkg.py
+++ b/cvelib/test_pkg.py
@@ -1,7 +1,6 @@
 """test_pkg.py: tests for pkg.py module"""
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/test_report.py
+++ b/cvelib/test_report.py
@@ -1,7 +1,6 @@
 """test_report.py: tests for report.py module"""
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated

--- a/cvelib/testutil.py
+++ b/cvelib/testutil.py
@@ -1,7 +1,6 @@
 """util.py; utility functions for tests"""
 #
-# Copyright (c) 2023 InfluxData
-# Author: Jamie Strandboge <jamie@influxdata.com>
+# Copyright (c) 2021-2023 InfluxData
 #
 # Permission is hereby granted, free of charge, to any
 # person obtaining a copy of this software and associated


### PR DESCRIPTION
GitHub is confused by the Author field so remove it (people can see who the author is in git logs).