### PR TITLE
feat: show secret scanning status by repo

### DIFF
--- a/bin/cve-report-updated-bugs
+++ b/bin/cve-report-updated-bugs
@@ -120,7 +120,7 @@ Example usage:
     parser.add_argument(
         "--gh-show-alerts-repo-status",
         dest="gh_show_alerts_repo_status",
-        help="show status of GitHub vulnerability alerts (dependabot) by repo",
+        help="show status of GitHub vulnerability alerts (dependabot and secrets scanning) by repo",
         action="store_true",
     )
     parser.add_argument(


### PR DESCRIPTION
- adjust _getGHReposAll() to store off archived instead of encoding in the repo name. Adjust _repoArchived() for this
- adjust _getGHReposAll() to store off secret_scanning by repo
- add _getGHSecretsScanningEnabled(). Add _repoSecretsScanning()
- getGHAlertsStatusReport() adjusted to also show secret scanning
- update bin/cve-report-updated-bugs to mention secret scanning