### PR TITLE
fix: require requests 2.28.2 and requests_cache 1.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ packages = find:
 python_requires >= 3.8
 install_requires =
     pyyaml
-    requests>=2.22
+    requests==2.28.2
 
 [options.entry_points]
 console_scripts =
@@ -32,7 +32,7 @@ console_scripts =
 
 [options.extras_require]
 cache =
-    requests_cache>=1.0
+    requests_cache==1.0.1
 dev =
     black==22.12.0
     coverage


### PR DESCRIPTION
requests_cache 1.0.1 when used with requests 2.29.0 raises the following exception when calling requests.get(..., allow_redirects=True) (the default) when receiving a 301 from GitHub (eg, with issues):

  AttributeError: 'dict' object has no attribute 'raw'

The latest requests_cache version (1.0.1) specifies requests 2.28.2 in its poetry.lock file and this version avoids this problem. As such, pin both versions.