### PR TITLE
feat: add security report fetching to gar-report

### DIFF
--- a/cvelib/gar.py
+++ b/cvelib/gar.py
@@ -5,14 +5,16 @@
 import argparse
 import copy
 from datetime import datetime
+import json
 import os
 import requests
 import sys
 import textwrap
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
-from cvelib.common import error, warn, _experimental
+from cvelib.common import error, warn, rePatterns, _experimental
 from cvelib.net import requestGetRaw
+from cvelib.scan import ScanOCI
 
 
 def _createGARHeaders() -> Dict[str, str]:
@@ -141,10 +143,14 @@ def _getGAROCIForRepo(project: str, location: str, repo: str) -> List[str]:
 
 
 # https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories.dockerImages
-def _getGARRepo(
-    project: str, location: str, repo: str, name: str, tagsearch: str = ""
-) -> str:
+# XXX: can we filter here?
+def _getGARRepo(repo_full: str) -> str:
     """Obtain the GAR digest for the specified project, location and repo"""
+    project, location, repo, name = repo_full.split("/", 4)
+    tagsearch: str = ""
+    if ":" in name:
+        name, tagsearch = name.split(":", 2)
+
     url: str = (
         "https://artifactregistry.googleapis.com/v1/projects/%s/locations/%s/repositories/%s/dockerImages"
         % (project, location, repo)
@@ -204,6 +210,241 @@ def _getGARRepo(
     return digest
 
 
+# {
+#   "occurrences": [
+#     {
+#       "resourceUri": "https://LOCATION-docker.pkg.dev/PROJECT/REPO/IMGNAME@sha256...",
+#       "vulnerability": {
+#         "severity": "...",
+#         "packageIssue": [
+#           {
+#             "packageType": "OS|GO_STDLIB",
+#             "affectedCpeUri": "<detectedIn for OS>",
+#             "affectedPackage": "<component name>",
+#             "affectedVersion": {
+#               "fullName": "<affected version>",
+#               ...
+#             },
+#             "fixedVersion": {
+#               "fullName": "<fixed version>",
+#               ...
+#             },
+#             "fileLocation": [
+#               {
+#                 "filePath": "<detectedIn of GO_STDLIB>",
+#               },
+#               ...
+#             ],
+#             ...
+#           },
+#           ...
+#         ],
+#         "shortDescription": "<if CVE..., used for advisory url>",
+#         ...
+#       },
+#       ...
+#     },
+#     ...
+#   ]
+# }
+def parse(vulns: List[Dict[str, Any]]) -> List[ScanOCI]:
+    """Parse report JSON and return a list of ScanOCIs"""
+    # Parse 'notes' (vulnerabilities)
+    # https://cloud.google.com/container-analysis/docs/reference/rest/v1/projects.notes#Note
+    # https://cloud.google.com/container-analysis/docs/reference/rest/v1/projects.notes#VulnerabilityNote
+
+    ocis: List[ScanOCI] = []
+
+    # createTime, updateTime
+    for v in vulns:
+        scan_data: Dict[str, str] = {}
+
+        if "vulnerability" not in v:
+            warn("Could not find 'vulnerability' in %s" % v)
+            continue
+
+        # https://cloud.google.com/container-analysis/docs/reference/rest/v1/projects.notes#Detail
+        # 'details' is not a thing in v1 and instead it is listed as
+        # 'packageIssue'). XXX: look for 'details' and 'windowsDetails'?
+        details_key: str = "packageIssue"
+        if details_key not in v["vulnerability"]:
+            warn("Could not find '%s' in %s" % (v["vulnerability"], details_key))
+            continue
+        if len(v["vulnerability"][details_key]) == 0:
+            warn("'%s' is empty in %s" % (details_key, v["vulnerability"]))
+            continue
+
+        # XXX: just use the first issue for now (anecdotally, seems to always
+        # only be a list of 1 anyway)
+        iss: Dict[str, Any] = v["vulnerability"][details_key][0]
+
+        if iss["packageType"] not in ["OS", "GO_STDLIB"]:
+            warn("unrecognized packageType '%s'" % iss["packageType"])
+            continue
+
+        if "affectedPackage" not in iss:
+            warn("Could not find 'affectedPackage' in %s" % iss)
+            continue
+
+        scan_data["component"] = iss["affectedPackage"]
+        scan_data["version"] = iss["affectedVersion"]["fullName"]
+        scan_data["url"] = v["resourceUri"]
+
+        # status
+        status: str = "needed"
+        if "fixedVersion" in iss:
+            if "fullName" not in iss["fixedVersion"]:
+                status = "needs-triage"
+            elif iss["fixedVersion"] == iss["affectedVersion"]:
+                status = "released"
+        scan_data["status"] = status
+
+        # detectedIn
+        detectedIn: str = "unknown"
+        if iss["packageType"] == "OS":
+            detectedIn = iss["affectedCpeUri"]
+        elif iss["packageType"] == "GO_STDLIB":
+            if "fileLocation" in iss and len(iss["fileLocation"]) > 0:
+                detectedIn = iss["fileLocation"][0]
+        scan_data["detectedIn"] = detectedIn
+
+        # severity - prefer distro severity over CVE priority
+        severity: str = "unknown"
+        if "effectiveSeverity" in iss:
+            severity = iss["effectiveSeverity"].lower()
+        elif "severity" in v["vulnerability"]:
+            severity = v["vulnerability"]["severity"].lower()
+        scan_data["severity"] = severity
+
+        # fixedBy
+        fixedBy: str = "unknown"
+        if "fixedVersion" in iss and "fullName" in iss["fixedVersion"]:
+            fixedBy = iss["fixedVersion"]["fullName"]
+        scan_data["fixedBy"] = fixedBy
+
+        # adv url
+        adv: str = "unknown"
+        if rePatterns["CVE"].search(v["vulnerability"]["shortDescription"]):
+            adv = (
+                "https://www.cve.org/CVERecord?id=%s"
+                % v["vulnerability"]["shortDescription"]
+            )
+        scan_data["advisory"] = adv
+
+        ocis.append(ScanOCI(scan_data))
+
+    return ocis
+
+
+# https://cloud.google.com/container-analysis/docs/investigate-vulnerabilities
+# https://cloud.google.com/container-analysis/docs/reference/rest
+def _getGARSecurityManifest(
+    repo_full: str,
+    raw: Optional[bool] = False,
+    fixable: Optional[bool] = False,
+) -> str:
+    """Obtain the security manifest for the specified repo@sha256:..."""
+    project, location, repo, name = repo_full.split("/", 4)
+
+    url: str = (
+        "https://containeranalysis.googleapis.com/v1/projects/%s/occurrences" % project
+    )
+    resource_url: str = "https://%s-docker.pkg.dev/%s/%s/%s" % (
+        location,
+        project,
+        repo,
+        name,
+    )
+    headers: Dict[str, str] = _createGARHeaders()
+    headers["Content-Type"] = "application/json"
+    params: Dict[str, str] = {
+        "filter": '(kind="VULNERABILITY" AND resourceUrl="%s")' % resource_url,
+    }
+
+    # the v1 format is (<noteN> is a vulnerability note):
+    # {
+    #   "occurrences": [
+    #     { note1 },
+    #     { note2 },
+    #   ],
+    #   "nextPageToken": "..."
+    # }
+    #
+    # Create a list of dictionaries with all the different pages added to a
+    # single list
+    vulns: List[Dict[str, Any]] = []
+    while True:
+        try:
+            r: requests.Response = requestGetRaw(url, headers=headers, params=params)
+        except requests.exceptions.RequestException as e:
+            warn("Skipping %s (request error: %s)" % (url, str(e)))
+            return ""
+
+        if r.status_code >= 300:
+            warn("Could not fetch %s" % url)
+            return ""
+
+        resj = r.json()
+        if "occurrences" not in resj:
+            error("Could not find 'occurrences' in response: %s" % resj)
+
+        vulns += resj["occurrences"]
+
+        if "nextPageToken" not in resj:
+            break
+
+        params["pageToken"] = resj["nextPageToken"]
+        # time.sleep(2)  # in case nextPageToken isn't valid yet
+
+    # If raw format, output a unified JSON document that has all the
+    # vulns in one doc but otherwise looks like that the API returned
+    if raw:
+        return "%s" % json.dumps({"occurrences": vulns})
+
+    # parse the vulns into ScanOCIs and then group them for the report
+    max_name: int = 0
+    max_vers: int = 0
+    grouped = {}
+    for i in parse(vulns):
+        if len(i.component) > max_name:
+            max_name = len(i.component)
+        if len(i.versionAffected) > max_vers:
+            max_vers = len(i.versionAffected)
+
+        if i.component not in grouped:
+            grouped[i.component] = {}
+            grouped[i.component]["version"] = i.versionAffected
+            grouped[i.component]["status"] = [i.status]
+            grouped[i.component]["severity"] = [i.severity]
+            continue
+        if i.status not in grouped[i.component]["status"]:
+            grouped[i.component]["status"].append(i.status)
+        if i.severity not in grouped[i.component]["severity"]:
+            grouped[i.component]["severity"].append(i.severity)
+
+    tableStr: str = "{name:%d} {vers:%d} {status}" % (max_name, max_vers)
+    table_f: object = tableStr.format
+    s: str = ""
+    for g in sorted(grouped.keys()):
+        status = "n/a"
+        if "needed" in grouped[g]["status"]:
+            status = "needed"
+        elif "unavailable" in grouped[g]["status"]:
+            status = "unavailable"
+        elif "released" in grouped[g]["status"]:
+            status = "released"
+
+        if fixable and status != "needed":
+            continue
+
+        if len(grouped[g]["severity"]) > 0:
+            status += " (%s)" % ",".join(sorted(grouped[g]["severity"]))
+
+        s += table_f(name=g, vers=grouped[g]["version"], status=status) + "\n"
+
+    return s.rstrip()
+
+
 #
 # CLI mains
 #
@@ -219,17 +460,30 @@ def main_gar_report():
             """\
 Example usage:
 
+# List all repos for the 'foo' PROJECT and 'us' LOCATION
 $ gar-report --list-repos foo/us
 bar
 baz
 
+# List all OCIs for the 'foo' PROJECT and 'us' LOCATION
 $ gar-report --list-ocis foo/us
 bar/norf
 bar/corge
 baz/qux
 
+# Get the latest digest for the 'foo' PROJECT, 'us' LOCATION, 'bar'
+# repository and 'norf' image name
 $ gar-report --get-repo-latest-digest foo/us/bar/norf
 norf@sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
+
+# Get the latest digest for the 'foo' PROJECT, 'us' LOCATION, 'bar' repository
+# and 'norf' image name with a particular tag
+$ gar-report --get-repo-latest-digest foo/us/bar/norf:some-tag
+norf@sha256:4993b5edd6b6f0b8361b85ba34f0c3595f95be62d086634247eca5982c8a8b26
+
+# Get the security report for the 'foo' PROJECT, 'us' LOCATION, 'bar'
+# repository, norf image name with a specific digest
+$ gar-report --get-security-manifest foo/us/bar/norf@sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
         """
         ),
     )
@@ -251,23 +505,29 @@ norf@sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
         "--get-repo-latest-digest",
         dest="get_repo_latest_digest",
         type=str,
-        help="output GAR repo digest for PROJECT/LOCATION/REPO/NAME[:<tagsearch>]",
+        help="output GAR repo digest for PROJECT/LOCATION/REPO/IMGNAME",
         default=None,
     )
-    #    parser.add_argument(
-    #        "--get-security-manifest",
-    #        dest="get_security_manifest",
-    #        type=str,
-    #        help="output GAR security report for ORG/REPO@sha256:SHA256",
-    #        default=None,
-    #    )
-    #    parser.add_argument(
-    #        "--get-security-manifest-raw",
-    #        dest="get_security_manifest_raw",
-    #        type=str,
-    #        help="output GAR raw security report for ORG/REPO@sha256:SHA256",
-    #        default=None,
-    #    )
+    parser.add_argument(
+        "--get-security-manifest",
+        dest="get_security_manifest",
+        type=str,
+        help="output GAR security report for PROJECT/LOCATION/REPO/IMGNAME@sha256:<sha256>",
+        default=None,
+    )
+    parser.add_argument(
+        "--get-security-manifest-raw",
+        dest="get_security_manifest_raw",
+        type=str,
+        help="output GAR raw security report for PROJECT/LOCATION/REPO/IMGNAME@sha256:<sha256>",
+        default=None,
+    )
+    parser.add_argument(
+        "--fixable",
+        dest="fixable",
+        help="show only fixables issues",
+        action="store_true",
+    )
     args: argparse.Namespace = parser.parse_args()
 
     # send to a report
@@ -288,29 +548,24 @@ norf@sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03
         for r in sorted(repos):
             print(r.split("/", maxsplit=5)[-1])  # trim off the proj/loc
     elif args.get_repo_latest_digest:
-        proj: str = ""
-        loc: str = ""
-        repo: str = ""
-        name: str = ""
-        tag: str = ""
-        if "/" not in args.get_repo_latest_digest:
-            error("please use PROJECT/LOCATION/REPO/NAME[:<tagsearch>]")
-
-        proj, loc, repo, name = args.get_repo_latest_digest.split("/", 4)
-        if ":" in name:
-            name, tag = name.split(":", 2)
-        digest: str = _getGARRepo(proj, loc, repo, name, tagsearch=tag)
+        if (
+            "/" not in args.get_repo_latest_digest
+            or args.get_repo_latest_digest.count("/") != 3
+        ):
+            error("please use PROJECT/LOCATION/REPO/IMGNAME")
+        digest: str = _getGARRepo(args.get_repo_latest_digest)
         print(digest.split("/")[-1])  # trim off the proj/loc/repo
+    elif args.get_security_manifest or args.get_security_manifest_raw:
+        arg: str
+        raw: bool = False
+        if args.get_security_manifest:
+            arg = args.get_security_manifest
+        else:
+            arg = args.get_security_manifest_raw
+            raw = True
 
+        if "/" not in arg or arg.count("/") != 3 or "@sha256:" not in arg:
+            error("please use PROJECT/LOCATION/REPO/IMGNAME@sha256:<sha256>")
 
-#    elif args.get_security_manifest:
-#        if "/" not in args.get_security_manifest:
-#            error("please use ORG/NAME")
-#        s: str = _getGARSecurityManifest(args.get_security_manifest)
-#        print("# %s report" % args.get_security_manifest)
-#        print(s)
-#    elif args.get_security_manifest_raw:
-#        if "/" not in args.get_security_manifest_raw:
-#            error("please use ORG/NAME")
-#        s: str = _getGARSecurityManifest(args.get_security_manifest_raw, raw=True)
-#        print(s)
+        s: str = _getGARSecurityManifest(arg, raw=raw, fixable=args.fixable)
+        print(s)

--- a/cvelib/gar.py
+++ b/cvelib/gar.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional
 
 from cvelib.common import error, warn, rePatterns, _experimental
 from cvelib.net import requestGetRaw
+from cvelib.report import getScanOCIsReport
 from cvelib.scan import ScanOCI
 
 
@@ -401,48 +402,9 @@ def _getGARSecurityManifest(
     if raw:
         return "%s" % json.dumps({"occurrences": vulns})
 
-    # parse the vulns into ScanOCIs and then group them for the report
-    max_name: int = 0
-    max_vers: int = 0
-    grouped = {}
-    for i in parse(vulns):
-        if len(i.component) > max_name:
-            max_name = len(i.component)
-        if len(i.versionAffected) > max_vers:
-            max_vers = len(i.versionAffected)
-
-        if i.component not in grouped:
-            grouped[i.component] = {}
-            grouped[i.component]["version"] = i.versionAffected
-            grouped[i.component]["status"] = [i.status]
-            grouped[i.component]["severity"] = [i.severity]
-            continue
-        if i.status not in grouped[i.component]["status"]:
-            grouped[i.component]["status"].append(i.status)
-        if i.severity not in grouped[i.component]["severity"]:
-            grouped[i.component]["severity"].append(i.severity)
-
-    tableStr: str = "{name:%d} {vers:%d} {status}" % (max_name, max_vers)
-    table_f: object = tableStr.format
-    s: str = ""
-    for g in sorted(grouped.keys()):
-        status = "n/a"
-        if "needed" in grouped[g]["status"]:
-            status = "needed"
-        elif "unavailable" in grouped[g]["status"]:
-            status = "unavailable"
-        elif "released" in grouped[g]["status"]:
-            status = "released"
-
-        if fixable and status != "needed":
-            continue
-
-        if len(grouped[g]["severity"]) > 0:
-            status += " (%s)" % ",".join(sorted(grouped[g]["severity"]))
-
-        s += table_f(name=g, vers=grouped[g]["version"], status=status) + "\n"
-
-    return s.rstrip()
+    ocis: List[ScanOCI] = parse(vulns)
+    s: str = getScanOCIsReport(ocis, fixable=fixable)
+    return s
 
 
 #

--- a/cvelib/quay.py
+++ b/cvelib/quay.py
@@ -10,7 +10,7 @@ import os
 import requests
 import sys
 import textwrap
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from cvelib.common import (
     error,
@@ -18,6 +18,7 @@ from cvelib.common import (
     _experimental,
 )
 from cvelib.net import requestGetRaw
+from cvelib.scan import ScanOCI
 
 
 def _createQuayHeaders() -> Dict[str, str]:
@@ -137,7 +138,101 @@ def _getQuayRepo(namespace: str, name: str, tagsearch: str = "") -> str:
     return digest
 
 
-# TODO: document the format
+# {
+#   "status": "scanned",
+#   "data": {
+#     "Layer": {
+#       "Features": [
+#         {
+#           "Name": "<component name>",
+#           "Version": "<affected version>",
+#           "Vulnerabilities": [
+#             {
+#               "Severity": "...",
+#               "Link": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-...",
+#               "FixedBy": "<fixed version>",
+#               "MetaData":
+#                 {
+#                   "RepoName": "...",
+#                   "DistroName": "...",
+#                   "DistroVersion": "...",
+#                 },
+#               ...
+def parse(resj: Dict[str, Any], url_prefix: str) -> List[ScanOCI]:
+    """Parse report JSON and return a list of ScanOCIs"""
+    ocis: List[ScanOCI] = []
+
+    for feature in resj["data"]["Layer"]["Features"]:
+        scan_data: Dict[str, str] = {}
+
+        if "Name" not in feature:
+            warn("Could not find 'Name' in %s" % feature)
+            continue
+        elif "Version" not in feature:
+            warn("Could not find 'Version' in %s" % feature)
+            continue
+        elif "Vulnerabilities" not in feature:
+            warn("Could not find 'Vulnerabilities' in %s" % feature)
+            continue
+
+        # One ScanOCI per vuln
+        for v in feature["Vulnerabilities"]:
+            scan_data["component"] = feature["Name"]
+            scan_data["version"] = feature["Version"]
+            scan_data["url"] = "%s?tab=vulnerabilities" % url_prefix
+
+            status: str = "needed"
+            if v["FixedBy"] == "" or v["FixedBy"] == "0:0":
+                status = "needs-triage"
+            elif v["FixedBy"] == feature["Version"]:
+                # TODO: >= (needs dpkg, rpm, alpine, etc)
+                status = "released"
+            scan_data["status"] = status
+
+            # detectedIn
+            detectedIn: str = "unknown"
+            if "MetaData" in v:
+                if (
+                    "RepoName" in v["Metadata"]
+                    and v["Metadata"]["RepoName"] is not None
+                ):
+                    detectedIn = "%s" % v["Metadata"]["RepoName"]
+                elif (
+                    "DistroName" in v["Metadata"]
+                    and v["Metadata"]["DistroName"] is not None
+                ):
+                    detectedIn = "%s" % v["Metadata"]["DistroName"]
+                    if (
+                        "DistroVersion" in v["Metadata"]
+                        and v["Metadata"]["DistroVersion"] is not None
+                    ):
+                        detectedIn += " %s" % v["Metadata"]["DistroVersion"]
+            scan_data["detectedIn"] = detectedIn
+
+            # severity
+            severity: str = "unknown"
+            if "Severity" in v:
+                severity = v["Severity"].lower()
+            scan_data["severity"] = severity
+
+            # fixedBy
+            fixedBy = "unavailable"
+            if v["FixedBy"] != "" and v["FixedBy"] != "0:0":
+                fixedBy = v["FixedBy"]
+            scan_data["fixedBy"] = fixedBy
+
+            # adv url
+            adv: str = "unknown"
+            if "Link" in v:
+                # Link may be a space-separated list
+                adv = v["Link"].split()[0]
+            scan_data["advisory"] = adv
+
+            ocis.append(ScanOCI(scan_data))
+
+    return ocis
+
+
 def _getQuaySecurityManifest(
     repo_full: str, raw: Optional[bool] = False, fixable: Optional[bool] = False
 ) -> str:
@@ -184,67 +279,49 @@ def _getQuaySecurityManifest(
     if "Features" not in resj["data"]["Layer"]:
         error("Could not find 'Features' in %s" % resj["data"]["Layer"])
 
-    features: Dict[str, Dict[str, str]] = {}
+    url_prefix: str = "https://quay.io/repository/%s/manifest/%s" % (repo, sha256)
+
+    # parse the vulns into ScanOCIs and then group them for the report
     max_name: int = 0
     max_vers: int = 0
-    for feature in resj["data"]["Layer"]["Features"]:
-        if "Name" not in feature:
-            error("Could not find 'Name' in %s" % feature)
-        elif "Version" not in feature:
-            error("Could not find 'Version' in %s" % feature)
-        elif "Vulnerabilities" not in feature:
-            error("Could not find 'Vulnerabilities' in %s" % feature)
+    grouped = {}
+    for i in parse(resj, url_prefix):
+        if len(i.component) > max_name:
+            max_name = len(i.component)
+        if len(i.versionAffected) > max_vers:
+            max_vers = len(i.versionAffected)
 
-        features[feature["Name"]] = {"version": feature["Version"]}
-
-        if len(feature["Name"]) > max_name:
-            max_name = len(feature["Name"])
-        if len(feature["Version"]) > max_vers:
-            max_vers = len(feature["Version"])
-
-        # n/a, unavailable, needed, released
-        severities: List[str] = []
-        statuses: List[str] = []
-
-        for vuln in feature["Vulnerabilities"]:
-            if vuln["FixedBy"] == "":
-                s = "unavailable"
-            elif (
-                vuln["FixedBy"] == feature["Version"]
-            ):  # TODO: >= (needs dpkg, rpm, alpine, etc)
-                s = "released"
-            else:
-                s = "needed"
-
-            if s not in statuses:
-                statuses.append(s)
-
-            if vuln["Severity"].lower() not in severities:
-                severities.append(vuln["Severity"].lower())
-
-        # XXX: clean this up
-        status = "n/a"
-        if "needed" in statuses:
-            status = "needed"
-        elif "unavailable" in statuses:
-            status = "unavailable"
-        elif "released" in statuses:
-            status = "released"
-
-        if len(severities) > 0:
-            status += " (%s)" % ",".join(sorted(severities))
-        features[feature["Name"]]["status"] = status
+        if i.component not in grouped:
+            grouped[i.component] = {}
+            grouped[i.component]["version"] = i.versionAffected
+            grouped[i.component]["status"] = [i.status]
+            grouped[i.component]["severity"] = [i.severity]
+            continue
+        if i.status not in grouped[i.component]["status"]:
+            grouped[i.component]["status"].append(i.status)
+        if i.severity not in grouped[i.component]["severity"]:
+            grouped[i.component]["severity"].append(i.severity)
 
     tableStr: str = "{name:%d} {vers:%d} {status}" % (max_name, max_vers)
     table_f: object = tableStr.format
     s: str = ""
-    for f in sorted(features.keys()):
-        if fixable and "needed" not in features[f]["status"]:
+    for g in sorted(grouped.keys()):
+        status = "n/a"
+        if "needed" in grouped[g]["status"]:
+            status = "needed"
+        elif "unavailable" in grouped[g]["status"]:
+            status = "unavailable"
+        elif "released" in grouped[g]["status"]:
+            status = "released"
+
+        if fixable and status != "needed":
             continue
-        s += (
-            table_f(name=f, vers=features[f]["version"], status=features[f]["status"])
-            + "\n"
-        )
+
+        if len(grouped[g]["severity"]) > 0:
+            status += " (%s)" % ",".join(sorted(grouped[g]["severity"]))
+
+        s += table_f(name=g, vers=grouped[g]["version"], status=status) + "\n"
+
     return s.rstrip()
 
 
@@ -321,16 +398,17 @@ $ quay-report
             name, tag = name.split(":", 2)
         digest: str = _getQuayRepo(ns, name, tagsearch=tag)
         print(digest)
-    elif args.get_security_manifest:
-        if "/" not in args.get_security_manifest:
-            error("please use ORG/NAME")
-        s: str = _getQuaySecurityManifest(
-            args.get_security_manifest, fixable=args.fixable
-        )
-        print("# %s report" % args.get_security_manifest)
-        print(s)
-    elif args.get_security_manifest_raw:
-        if "/" not in args.get_security_manifest_raw:
-            error("please use ORG/NAME")
-        s: str = _getQuaySecurityManifest(args.get_security_manifest_raw, raw=True)
+    elif args.get_security_manifest or args.get_security_manifest_raw:
+        arg: str
+        raw: bool = False
+        if args.get_security_manifest:
+            arg = args.get_security_manifest
+        else:
+            arg = args.get_security_manifest_raw
+            raw = True
+
+        if "/" not in arg or "@sha256:" not in arg:
+            error("please use ORG/NAME@sha256:<sha256>")
+
+        s: str = _getQuaySecurityManifest(arg, raw=raw, fixable=args.fixable)
         print(s)

--- a/cvelib/scan.py
+++ b/cvelib/scan.py
@@ -90,7 +90,7 @@ class ScanOCI(object):
 
     def setSeverity(self, s: str) -> None:
         """Set severity"""
-        if s not in cve_priorities:
+        if s not in cve_priorities and s != "unknown":
             raise CveException("invalid severity: %s" % s)
         self.severity = s
 

--- a/cvelib/scan.py
+++ b/cvelib/scan.py
@@ -12,6 +12,7 @@ from cvelib.common import CveException, cve_priorities, rePatterns, _experimenta
 #    component: ...
 #    detectedIn: <image name@sha256:...>
 #    advisory: https://.../CVE-... (relevant security advisory)
+#    version: <version>
 #    fixedBy: <version>
 #    severity: negligible|low|medium|high|critical
 #    status: needs-triage|needed|released|dismissed (tolerable|code-not-used; name)
@@ -23,6 +24,7 @@ class ScanOCI(object):
         "component",
         "detectedIn",
         "severity",
+        "version",
         "fixedBy",
         "status",
         "advisory",
@@ -38,7 +40,8 @@ class ScanOCI(object):
         s += "   component: %s\n" % self.component
         s += "   detectedIn: %s\n" % self.detectedIn
         s += "   advisory: %s\n" % self.advisory
-        s += "   fixedBy: %s\n" % self.fixedBy
+        s += "   version: %s\n" % self.versionAffected
+        s += "   fixedBy: %s\n" % self.versionFixed
         s += "   severity: %s\n" % self.severity
         s += "   status: %s\n" % self.status
         s += "   url: %s" % self.url
@@ -50,7 +53,8 @@ class ScanOCI(object):
         self.component: str = ""
         self.detectedIn: str = ""
         self.advisory: str = ""
-        self.fixedBy: str = ""
+        self.versionAffected: str = ""
+        self.versionFixed: str = ""
         self.severity: str = ""
         self.status: str = ""
         self.url: str = ""
@@ -60,7 +64,8 @@ class ScanOCI(object):
         self.setComponent(data["component"])
         self.setDetectedIn(data["detectedIn"])
         self.setSeverity(data["severity"])
-        self.setFixedBy(data["fixedBy"])
+        self.setVersionAffected(data["version"])
+        self.setVersionFixed(data["fixedBy"])
         self.setStatus(data["status"])
         self.setAdvisory(data["advisory"])
         self.setUrl(data["url"])
@@ -89,9 +94,13 @@ class ScanOCI(object):
             raise CveException("invalid severity: %s" % s)
         self.severity = s
 
-    def setFixedBy(self, s: str) -> None:
+    def setVersionAffected(self, s: str) -> None:
+        """Set version"""
+        self.versionAffected = s
+
+    def setVersionFixed(self, s: str) -> None:
         """Set fixedBy"""
-        self.fixedBy = s
+        self.versionFixed = s
 
     def setStatus(self, s: str) -> None:
         """Set status"""

--- a/tests/test_cve.py
+++ b/tests/test_cve.py
@@ -147,6 +147,7 @@ class TestCve(TestCase):
    component: foo
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0001
+   version: 1.2.2
    fixedBy: 1.2.3
    severity: medium
    status: needed
@@ -155,6 +156,7 @@ class TestCve(TestCase):
    component: baz
    detectedIn: myorg/myimg2@sha256:deadbeef1
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0002
+   version: 2.3.3
    fixedBy: 2.3.4
    severity: medium
    status: needed
@@ -163,6 +165,7 @@ class TestCve(TestCase):
    component: corge
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0003
+   version: 9.2.0-4
    fixedBy: 9.2.0-5
    severity: high
    status: released
@@ -204,6 +207,7 @@ Scan-Reports:
    component: foo
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0001
+   version: 1.2.2
    fixedBy: 1.2.3
    severity: medium
    status: needed
@@ -212,6 +216,7 @@ Scan-Reports:
    component: baz
    detectedIn: myorg/myimg2@sha256:deadbeef1
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0002
+   version: 2.3.3
    fixedBy: 2.3.4
    severity: medium
    status: needed
@@ -220,6 +225,7 @@ Scan-Reports:
    component: corge
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0003
+   version: 9.2.0-4
    fixedBy: 9.2.0-5
    severity: high
    status: released
@@ -1411,6 +1417,7 @@ git/github_norf: needs-triage
    component: foo
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://blah.com/BAR-a
+   version: 1.2.3-0
    fixedBy: 1.2.3-1
    severity: medium
    status: dismissed (tolerable; who)
@@ -1426,6 +1433,7 @@ git/github_norf: needs-triage
    component: bár
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://blah.com/BAR-a
+   version: 1.2.3-0
    fixedBy: 1.2.3-1
    severity: medium
    status: dismissed (tolerable; who)
@@ -1436,6 +1444,7 @@ git/github_norf: needs-triage
    component: bár
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://blah.com/BAR-a
+   version: 1.2.3-0
    fixedBy: 1.2.3-1
    severity: medium
    status: dismissed (tolerable; who)
@@ -2199,6 +2208,7 @@ cve-data = %s
    component: foo
    detectedIn: myorg/myimg@sha256:deadbeef1
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0001
+   version: 1.2.2
    fixedBy: 1.2.3
    severity: medium
    status: needed
@@ -2207,6 +2217,7 @@ cve-data = %s
    component: bar
    detectedIn: myorg/myimg@sha256:deadbeef1
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0002
+   version: 2.3.3
    fixedBy: 2.3.4
    severity: medium
    status: needed
@@ -2215,6 +2226,7 @@ cve-data = %s
    component: baz
    detectedIn: myorg/myimg@sha256:deadbeef1
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0002
+   version: 3.4.4
    fixedBy: 3.4.5
    severity: high
    status: needed
@@ -2251,6 +2263,7 @@ cve-data = %s
    component: foo
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://blah.com/BAR-a
+   version: 1.2.3-0
    fixedBy: 1.2.3-1
    severity: medium
    status: needed
@@ -2283,6 +2296,7 @@ cve-data = %s
    component: foo
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://blah.com/BAR-a
+   version: 1.2.3-0
    fixedBy: 1.2.3-1
    severity: medium
    status: released
@@ -2316,6 +2330,7 @@ cve-data = %s
    component: foo
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://blah.com/BAR-a
+   version: 1.2.3-0
    fixedBy: 1.2.3-1
    severity: medium
    status: released

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -245,6 +245,7 @@ class TestScanOCI(TestCase):
             ("medium", None),
             ("low", None),
             ("negligible", None),
+            ("unknown", None),
             # invalid
             ("foo", "invalid severity: foo"),
         ]

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -28,6 +28,7 @@ class TestScanOCI(TestCase):
             "component": "foo",
             "detectedIn": "myorg/myimg@sha256:deadbeef",
             "advisory": "https://www.cve.org/CVERecord?id=CVE-2023-0001",
+            "version": "1.2.2",
             "fixedBy": "1.2.3",
             "severity": "medium",
             "status": "needed",
@@ -42,6 +43,7 @@ class TestScanOCI(TestCase):
    component: foo
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0001
+   version: 1.2.2
    fixedBy: 1.2.3
    severity: medium
    status: needed
@@ -57,6 +59,7 @@ class TestScanOCI(TestCase):
    component: foo
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0001
+   version: 1.2.2
    fixedBy: 1.2.3
    severity: medium
    status: needed
@@ -76,6 +79,7 @@ class TestScanOCI(TestCase):
                     "cmponent": "foo",
                     "detectedIn": "myorg/myimg@sha256:deadbeef",
                     "advisory": "https://www.cve.org/CVERecord?id=CVE-2023-0001",
+                    "version": "1.2.2",
                     "fixedBy": "1.2.3",
                     "severity": "medium",
                     "status": "needed",
@@ -88,6 +92,7 @@ class TestScanOCI(TestCase):
                     "component": "foo",
                     "dtectedIn": "myorg/myimg@sha256:deadbeef",
                     "advisory": "https://www.cve.org/CVERecord?id=CVE-2023-0001",
+                    "version": "1.2.2",
                     "fixedBy": "1.2.3",
                     "status": "needed",
                     "url": "https://blah.com/BAR-a",
@@ -99,6 +104,7 @@ class TestScanOCI(TestCase):
                     "component": "foo",
                     "detectedIn": "myorg/myimg@sha256:deadbeef",
                     "avisory": "https://www.cve.org/CVERecord?id=CVE-2023-0001",
+                    "version": "1.2.2",
                     "fixedBy": "1.2.3",
                     "severity": "medium",
                     "status": "needed",
@@ -111,6 +117,20 @@ class TestScanOCI(TestCase):
                     "component": "foo",
                     "detectedIn": "myorg/myimg@sha256:deadbeef",
                     "advisory": "https://www.cve.org/CVERecord?id=CVE-2023-0001",
+                    "vrsion": "1.2.2",
+                    "fixedBy": "1.2.3",
+                    "severity": "medium",
+                    "status": "needed",
+                    "url": "https://blah.com/BAR-a",
+                },
+                "missing required field 'version'",
+            ),
+            (
+                {
+                    "component": "foo",
+                    "detectedIn": "myorg/myimg@sha256:deadbeef",
+                    "advisory": "https://www.cve.org/CVERecord?id=CVE-2023-0001",
+                    "version": "1.2.2",
                     "fxedBy": "1.2.3",
                     "severity": "medium",
                     "status": "needed",
@@ -123,6 +143,7 @@ class TestScanOCI(TestCase):
                     "component": "foo",
                     "detectedIn": "myorg/myimg@sha256:deadbeef",
                     "advisory": "https://www.cve.org/CVERecord?id=CVE-2023-0001",
+                    "version": "1.2.2",
                     "fixedBy": "1.2.3",
                     "sverity": "medium",
                     "status": "needed",
@@ -135,6 +156,7 @@ class TestScanOCI(TestCase):
                     "component": "foo",
                     "detectedIn": "myorg/myimg@sha256:deadbeef",
                     "advisory": "https://www.cve.org/CVERecord?id=CVE-2023-0001",
+                    "version": "1.2.2",
                     "fixedBy": "1.2.3",
                     "severity": "medium",
                     "satus": "needed",
@@ -147,6 +169,7 @@ class TestScanOCI(TestCase):
                     "component": "foo",
                     "detectedIn": "myorg/myimg@sha256:deadbeef",
                     "advisory": "https://www.cve.org/CVERecord?id=CVE-2023-0001",
+                    "version": "1.2.2",
                     "fixedBy": "1.2.3",
                     "severity": "medium",
                     "status": "needed",
@@ -159,6 +182,7 @@ class TestScanOCI(TestCase):
                     "component": "",
                     "detectedIn": "myorg/myimg@sha256:deadbeef",
                     "advisory": "https://www.cve.org/CVERecord?id=CVE-2023-0001",
+                    "version": "1.2.2",
                     "fixedBy": "1.2.3",
                     "severity": "medium",
                     "status": "needed",
@@ -171,6 +195,7 @@ class TestScanOCI(TestCase):
                     "component": "foo\nbar",
                     "detectedIn": "myorg/myimg@sha256:deadbeef",
                     "advisory": "https://www.cve.org/CVERecord?id=CVE-2023-0001",
+                    "version": "1.2.2",
                     "fixedBy": "1.2.3",
                     "severity": "medium",
                     "status": "needed",
@@ -233,8 +258,8 @@ class TestScanOCI(TestCase):
                     sm.setSeverity(s)
                 self.assertEqual(expErr, str(context.exception))
 
-    def test_setFixedBy(self):
-        """Test setFixedBy()"""
+    def test_setVersionFixed(self):
+        """Test setVersionFixed()"""
         tsts = [
             # valid
             ("foo"),
@@ -242,7 +267,7 @@ class TestScanOCI(TestCase):
 
         for s in tsts:
             sm = cvelib.scan.ScanOCI(self._getValid())
-            sm.setFixedBy(s)
+            sm.setVersionFixed(s)
 
     def test_setStatus(self):
         """Test setStatus()"""
@@ -330,6 +355,7 @@ class TestScanCommon(TestCase):
    component: foo
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0001
+   version: 1.2.2
    fixedBy: 1.2.3
    severity: medium
    status: needed
@@ -338,6 +364,7 @@ class TestScanCommon(TestCase):
    component: baz
    detectedIn: myorg/myimg2@sha256:deadbeef1
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0002
+   version: 2.3.3
    fixedBy: 2.3.4
    severity: medium
    status: needed
@@ -346,6 +373,7 @@ class TestScanCommon(TestCase):
    component: corge
    detectedIn: myorg/myimg@sha256:deadbeef
    advisory: https://www.cve.org/CVERecord?id=CVE-2023-0003
+   version: 9.2.0-4
    fixedBy: 9.2.0-5
    severity: high
    status: released


### PR DESCRIPTION
* feat: add 'version' to ScanOCI for tracking affected version
* feat: allow 'unknown' for ScanOCI severity
* feat: add security report fetching to gar-report
* chore: use ScanOCI as part of parsing reports in quay-report
* chore: refactor ScanOCI report into cvelib.report.getScanOCIsReport()