### PR TITLE
chore: update to requests 2.31.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ packages = find:
 python_requires >= 3.8
 install_requires =
     pyyaml
-    requests==2.28.2
+    requests>=2.31.0
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
0dcd8417 downgraded requests to 2.28.2 since requests_cache 1.0.1 specified it. requests 2.31.0 fixes a security issue so in the future will try to work around any issues that 0dcd8417 in another way.